### PR TITLE
Moving Estonia, Lithuania, and Latvia to the euro

### DIFF
--- a/ISO4217.php
+++ b/ISO4217.php
@@ -414,8 +414,8 @@ class ISO4217
             'alpha3' => 'EUR',
             'numeric' => '978',
             'exp' => 2,
-            'country' => array('AD', 'AT', 'AX', 'BE', 'BL', 'CY', 'DE', 'ES', 'FI', 'FR', 'GF', 'GP', 'GR', 'IE', 'IT', 'LU', 'MC',
-                'ME', 'MF', 'MQ', 'MT', 'NL', 'PM', 'PT', 'RE', 'SI', 'SK', 'SM', 'TF', 'VA', 'YT', 'ZW'),
+            'country' => array('AD', 'AT', 'AX', 'BE', 'BL', 'CY', 'DE', 'EE', 'ES', 'FI', 'FR', 'GF', 'GP', 'GR', 'IE', 'IT', 'LT',
+                'LU', 'LV', 'MC', 'ME', 'MF', 'MQ', 'MT', 'NL', 'PM', 'PT', 'RE', 'SI', 'SK', 'SM', 'TF', 'VA', 'YT', 'ZW'),
         ),
         array(
             'name' => 'Fiji Dollar',
@@ -683,20 +683,6 @@ class ISO4217
             'numeric' => '426',
             'exp' => 2,
             'country' => 'LS',
-        ),
-        array(
-            'name' => 'Lithuanian Litas',
-            'alpha3' => 'LTL',
-            'numeric' => '440',
-            'exp' => 2,
-            'country' => 'LT',
-        ),
-        array(
-            'name' => 'Latvian Lats',
-            'alpha3' => 'LVL',
-            'numeric' => '428',
-            'exp' => 2,
-            'country' => 'LV',
         ),
         array(
             'name' => 'Libyan Dinar',

--- a/ISO4217Test.php
+++ b/ISO4217Test.php
@@ -134,7 +134,7 @@ class ISO4217Test extends \PHPUnit_Framework_TestCase
         $currencies = $iso4217->findAll();
 
         $this->assertInternalType('array', $currencies);
-        $this->assertCount(157, $currencies);
+        $this->assertCount(155, $currencies);
 
         $this->assertContainsOnly('Payum\ISO4217\Currency', $currencies);
     }


### PR DESCRIPTION
These three countries have all joined the eurozone: https://en.wikipedia.org/wiki/Eurozone. I'd like to update the currency data to group them under the Euro and also remove the Lithuanian Litas and the Latvian Lats since they are no longer in use.