### PR TITLE
Add tests to `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
 .gitattributes export-ignore
 .gitignore export-ignore
 .travis.yml export-ignore
+phpunit.xml.dist export-ignore
+*Test.php export-ignore


### PR DESCRIPTION
Currently, composer warns about the test files not complying to PSR-4:
```
Class Payum\ISO4217\Tests\CurrencyTest located in ./vendor/payum/iso4217/CurrencyTest.php does not comply with psr-4 autoloading standard. Skipping.
Class Payum\ISO4217\Tests\ISO4217Test located in ./vendor/payum/iso4217/ISO4217Test.php does not comply with psr-4 autoloading standard. Skipping.
```

As those files are not needed when installing the package, I added them to `.gitattributes` which fixes the warning.